### PR TITLE
Improve typing in `setState`

### DIFF
--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -108,11 +108,12 @@ class ReactTypeMacro
 	) {
 		fields.push((macro class C {
 			@:extern
-			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
+			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			override public function setState(state: react.Partial<$stateType>, ?callback:Void -> Void): Void
-				#if (haxe_ver < 4)
-				{ super.setState(nextState, callback); }
+				#if (haxe4 || haxe_ver >= 4.0) // some preview builds required the function body and also didn't set the haxe4 flag
+				#else
+				{ super.setState(state, callback); }
 				#end
 			;
 		}).fields[0]);

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -106,12 +106,15 @@ class ReactTypeMacro
 		propsType:ComplexType,
 		stateType:ComplexType
 	) {
+		trace(Context.getDefines());
 		fields.push((macro class C {
 			@:extern
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			override public function setState(nextState: react.Partial<$stateType>, ?callback:Void -> Void): Void
-				#if (haxe4 || haxe_ver > 4.0) // some preview builds required the function body and also didn't set the haxe4 flag
+				#if (haxe4 || haxe_ver > 4.0)
+				// explictly omit function body
+				// newer haxe 4 builds (preview 5 and up) don't require a function body – however haxe4 flag is not set until rc1
 				#else
 				{ super.setState(nextState, callback); }
 				#end

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -110,7 +110,7 @@ class ReactTypeMacro
 			@:extern
 			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
-			override public function setState(state: react.Partial<$stateType>): Void
+			override public function setState(state: react.Partial<$stateType>, ?callback:Void -> Void): Void
 				#if (haxe_ver < 4)
 				{ super.setState(nextState, callback); }
 				#end
@@ -118,27 +118,5 @@ class ReactTypeMacro
 		}).fields[0]);
 	}
 
-	static function generateSetStateOverload(nextStateType:ComplexType) {
-		return {
-			expr: EFunction(null, {
-				args: [
-					{
-						name: 'nextState',
-						type: nextStateType,
-						opt: false
-					},
-					{
-						name: 'callback',
-						type: macro :Void->Void,
-						opt: true
-					}
-				],
-				expr: macro {},
-				params: null,
-				ret: macro :Void
-			}),
-			pos: Context.currentPos()
-		};
-	}
 	#end
 }

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -106,7 +106,6 @@ class ReactTypeMacro
 		propsType:ComplexType,
 		stateType:ComplexType
 	) {
-		trace(Context.getDefines());
 		fields.push((macro class C {
 			@:extern
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -111,7 +111,7 @@ class ReactTypeMacro
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			override public function setState(nextState: react.Partial<$stateType>, ?callback:Void -> Void): Void
-				#if (haxe4 || haxe_ver > 4.0)
+				#if haxe4
 				// explictly omit function body
 				// newer haxe 4 builds (preview 5 and up) don't require a function body – however haxe4 flag is not set until rc1
 				#else

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -110,10 +110,10 @@ class ReactTypeMacro
 			@:extern
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
-			override public function setState(state: react.Partial<$stateType>, ?callback:Void -> Void): Void
+			override public function setState(nextState: react.Partial<$stateType>, ?callback:Void -> Void): Void
 				#if (haxe4 || haxe_ver > 4.0) // some preview builds required the function body and also didn't set the haxe4 flag
 				#else
-				{ super.setState(state, callback); }
+				{ super.setState(nextState, callback); }
 				#end
 			;
 		}).fields[0]);

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -111,7 +111,7 @@ class ReactTypeMacro
 			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
 			override public function setState(state: react.Partial<$stateType>, ?callback:Void -> Void): Void
-				#if (haxe4 || haxe_ver >= 4.0) // some preview builds required the function body and also didn't set the haxe4 flag
+				#if (haxe4 || haxe_ver > 4.0) // some preview builds required the function body and also didn't set the haxe4 flag
 				#else
 				{ super.setState(state, callback); }
 				#end

--- a/src/lib/react/macro/ReactTypeMacro.hx
+++ b/src/lib/react/macro/ReactTypeMacro.hx
@@ -109,8 +109,8 @@ class ReactTypeMacro
 		fields.push((macro class C {
 			@:extern
 			@:overload(function(nextState:$stateType -> $propsType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
-			@:overload(function(state: react.Partial<$stateType>):Void {})
-			override public function setState(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void): Void
+			@:overload(function(nextState:$stateType -> react.Partial<$stateType>, ?callback:Void -> Void):Void {})
+			override public function setState(state: react.Partial<$stateType>): Void
 				#if (haxe_ver < 4)
 				{ super.setState(nextState, callback); }
 				#end

--- a/test/src/react/ReactComponent.hx
+++ b/test/src/react/ReactComponent.hx
@@ -12,8 +12,8 @@ typedef ReactComponentProps = {
 	STUB CLASSES
 **/
 typedef ReactComponent = ReactComponentOf<Dynamic, Dynamic>;
-typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Void>;
-typedef ReactComponentOfState<TState> = ReactComponentOf<Void, TState>;
+typedef ReactComponentOfProps<TProps> = ReactComponentOf<TProps, Empty>;
+typedef ReactComponentOfState<TState> = ReactComponentOf<Empty, TState>;
 
 #if react_deprecated_refs
 // Keep the old ReactComponentOfPropsAndState typedef available for a few versions
@@ -45,7 +45,9 @@ class ReactComponentOf<TProps, TState>
 	/**
 		https://facebook.github.io/react/docs/react-component.html#setstate
 	**/
-	function setState(nextState:Dynamic, ?callback:Void -> Void):Void {};
+	@:overload(function(nextState:TState -> TState, ?callback:Void -> Void):Void {})
+	@:overload(function(nextState:TState -> TProps -> TState, ?callback:Void -> Void):Void {})
+	function setState(nextState:TState, ?callback:Void -> Void):Void {};
 
 	/**
 		https://facebook.github.io/react/docs/react-component.html#render


### PR DESCRIPTION
Hey @kLabz, thanks for pushing the react externs forwards! I've just started using this branch in a side project.

While having a typing issue I was debugging `addSetStateType` and realised it could be made easier to read – a little known trick is that you can macro-reify field expressions by wrapping them in a dummy class (works in haxe 3).

This change also swaps the order of overloads so the primary signature is `setState(Partial<TState>)`. This means that haxe can better infer TState's field types when calling set state. For example, this now works
```haxe
setState({
    someEnum: SomeEnumValue
});
```

Whereas before it would have failed with "Unknown identifier : SomeEnumValue" and you'd need to tell haxe that this field has type SomeEnum. So the workaround was
```haxe
setState({
    someEnum: SomeEnum.SomeEnumValue
});
```

This sort of change could be made to more of the macro code but I've only done this method for now