### PR TITLE
Remove hamcrest as a test dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
 
 install:
   - haxelib install munit
-  - haxelib install hamcrest
   - haxelib install hxnodejs
   - haxelib install tink_hxx
 

--- a/test/test.hxml
+++ b/test/test.hxml
@@ -1,6 +1,5 @@
 -main TestMain
 -lib munit
--lib hamcrest
 -lib tink_hxx
 -cp src/lib
 


### PR DESCRIPTION
It's unused and causes the haxe 4 nightly test to fail