### PR TITLE
More reliable check against defining JsxStaticInit__ twice.

### DIFF
--- a/src/lib/react/jsx/JsxStaticMacro.hx
+++ b/src/lib/react/jsx/JsxStaticMacro.hx
@@ -220,11 +220,11 @@ class JsxStaticMacro
 	{
 		var initModule = "JsxStaticInit__";
 
-		for (m in modules) switch (m) {
-			case TClassDecl(_.toString() => "JsxStaticInit__"):
-				return;
-			case _:
+		try {
+			Context.getType(initModule);
+			return;
 		}
+		catch (e:Dynamic) {}
 
 		var exprs = decls.map(function(decl) {
 			var fName = decl.fieldName;


### PR DESCRIPTION
We also have an onAfterTyping hook, which makes this one rerun and apparently looping over all types doesn't do the trick.