### PR TITLE
Convert array primitives to ReactFragment

### DIFF
--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -147,4 +147,7 @@ typedef ReactElement = {
 	from ReactSingleFragment
 	from Array<ReactFragment>
 	from Array<ReactElement>
+	from Array<String>
+	from Array<Float>
+	from Array<Bool>
 	from Array<ReactSingleFragment> {}


### PR DESCRIPTION
For example, currently this won't work:

```haxe
var frag:ReactFragment = ['foo'];
```