### PR TITLE
Cast from Array<Int> to ReactFragment

### DIFF
--- a/src/lib/react/ReactComponent.hx
+++ b/src/lib/react/ReactComponent.hx
@@ -160,5 +160,6 @@ typedef ReactElement = {
 	from Array<ReactElement>
 	from Array<String>
 	from Array<Float>
+	from Array<Int>
 	from Array<Bool>
 	from Array<ReactSingleFragment> {}


### PR DESCRIPTION
At _some_ haxe versions the `Array<Float>` casts doesn't work for `Array<Int>` actually...