### PR TITLE
Make ReactTypeOf easier to use from coconut.

### DIFF
--- a/src/lib/react/ReactType.hx
+++ b/src/lib/react/ReactType.hx
@@ -140,6 +140,13 @@ abstract ReactTypeOf<TProps>(ReactType) to ReactType {
 	}
 	#end
 
+	#if coconut_react_core
+	public function fromHxx(hxxMeta:{ ?key:coconut.react.Key }, props:TProps):ReactElement
+	{
+		return React.createElement(this, js.Object.assign(cast props, hxxMeta));
+	}
+	#end
+
 	@:from
 	static public macro function fromExpr(expr:Expr)
 	{


### PR DESCRIPTION
Right now I have some awkward global build macro accomplishing the same but since it starts breaking with haxe 4.2, it would be nice to support directly ;)