### PR TITLE
Fix ES6 init fields for ReactComponent classes

### DIFF
--- a/src/lib/react/macro/ReactComponentMacro.hx
+++ b/src/lib/react/macro/ReactComponentMacro.hx
@@ -200,6 +200,23 @@ class ReactComponentMacro {
 			var fname = f.name;
 			fieldInits.push(macro this.$fname = $e);
 
+			// Guess constant types
+			if (t == null) {
+				switch (e.expr) {
+					case EConst(c):
+						t = switch (c) {
+							case CInt(_): macro :Int;
+							case CFloat(_): macro :Float;
+							case CString(_, _): macro :String;
+							case CRegexp(_, _): macro :EReg;
+							case CIdent('true') | CIdent('false'): macro :Bool;
+							case CIdent(_): null;
+						};
+
+					case _:
+				}
+			}
+
 			if (t == null) {
 				// Rewrite error to remove the confusing part
 				Context.error('Variable requires type-hint', f.pos);

--- a/src/lib/react/macro/ReactComponentMacro.hx
+++ b/src/lib/react/macro/ReactComponentMacro.hx
@@ -190,8 +190,8 @@ class ReactComponentMacro {
 	#if (js_es == '6')
 	// Rewrite field inits for ES6 generator: remove init expressions and move
 	// them right after super() call
-	// Note: it's still unsafe because those fields could be used before
-	// `super()`; need a second pass to ensure that it's fine
+	// Note: it's safe because if you use those fields before super() call, haxe
+	// will see it and generate "Must call `super()` [...]" error accordingly
 	static public function fixES6Constructor(inClass:ClassType, fields:Array<Field>):Array<Field> {
 		var fieldInits = [];
 		var constructor:Null<Field> = null;

--- a/src/lib/react/macro/ReactComponentMacro.hx
+++ b/src/lib/react/macro/ReactComponentMacro.hx
@@ -200,7 +200,6 @@ class ReactComponentMacro {
 			var fname = f.name;
 			fieldInits.push(macro this.$fname = $e);
 
-			if (t == null) t = TypeTools.toComplexType(Context.typeof(e));
 			if (t == null) {
 				// Rewrite error to remove the confusing part
 				Context.error('Variable requires type-hint', f.pos);

--- a/src/lib/react/macro/ReactComponentMacro.hx
+++ b/src/lib/react/macro/ReactComponentMacro.hx
@@ -219,8 +219,10 @@ class ReactComponentMacro {
 
 			if (t == null) {
 				// Rewrite error to remove the confusing part
-				Context.error('Variable requires type-hint', f.pos);
-				Context.error('... Defined in this class', inClass.pos);
+				// Need to use fatal error to make sure the build macro
+				// chain stops and this error is not shadowed by some
+				// unexpected side effect
+				Context.fatalError('Variable requires type-hint', f.pos);
 			}
 
 			return t;

--- a/src/lib/react/macro/ReactDebugMacro.hx
+++ b/src/lib/react/macro/ReactDebugMacro.hx
@@ -55,9 +55,9 @@ class ReactDebugMacro
 			{
 				switch (field.kind) {
 					case FFun(f):
-						f.expr = macro {
-							${f.expr}
-							${exprConstructor(inClass)}
+						f.expr = macro @:pos(field.pos) @:mergeBlock {
+							@:mergeBlock ${f.expr};
+							@:mergeBlock ${exprConstructor(inClass)};
 						};
 
 						return true;


### PR DESCRIPTION
See https://github.com/HaxeFoundation/haxe/pull/10197

Note: still needs https://github.com/HaxeFoundation/haxe/issues/10193 fixes to avoid breaking with `function new(props) { super(props); // ... }`, so a very recent nightly is needed (or 4.2.2+ which is unreleased as of yet, but this fix will be included).