### PR TITLE
Fix JSX macro error

### DIFF
--- a/src/lib/react/ReactMacro.hx
+++ b/src/lib/react/ReactMacro.hx
@@ -475,7 +475,10 @@ class ReactMacro
 				}
 
 				// Support "import as"
-				function deepFollow(t:Type) return TypeTools.map(Context.follow(t), deepFollow);
+				function deepFollow(t:Type) {
+					if (t == null) return null;
+					return TypeTools.map(Context.follow(t), deepFollow);
+				}
 
 				var t = deepFollow(Context.typeof(macro {
 					var __pseudo = $target;

--- a/test/src/ReactMacroTest.hx
+++ b/test/src/ReactMacroTest.hx
@@ -14,6 +14,9 @@ class CompBasic extends ReactComponent {}
 @:ignoreEmptyRender
 class CompBasicProps extends ReactComponentOfProps<{a:Int}> {}
 
+@:ignoreEmptyRender
+class CompRenderFunctionProps extends ReactComponentOfProps<{?render:()->ReactElement}> {}
+
 typedef RenderProps = {
 	@:optional var children:Int->ReactFragment;
 }
@@ -407,6 +410,16 @@ class ReactMacroTest
 			}
 			Assert.areEqual(if (flag) 0 else 9, counter);
 		}
+	}
+
+	@Test
+	public function render_function_props() {
+		function fn() return jsx('<></>');
+		var e = jsx('<CompRenderFunctionProps render=${fn}/>');
+		assertHasProps(
+			e.props,
+			['render'], [fn]
+		);
 	}
 
 	@Test


### PR DESCRIPTION
`ReactMacro.jsx()` can not process this code:

```haxe
class CompRenderFunctionProps extends ReactComponentOfProps<{?render:()->ReactElement}> {}

function fn() return jsx('<></>');
ReactMacro.jsx('<CompRenderFunctionProps render=${fn}/>');
```